### PR TITLE
Set caret to end of selection when editing bio.

### DIFF
--- a/app/src/main/java/com/github/q115/goalie_android/ui/profile/UpdateProfileDialog.java
+++ b/app/src/main/java/com/github/q115/goalie_android/ui/profile/UpdateProfileDialog.java
@@ -93,6 +93,7 @@ public class UpdateProfileDialog extends DialogFragment {
         profileBioInput.setOnEditorActionListener(handleEditorAction());
         profileBioInput.setSingleLine(false);
         profileBioInput.setText(mBio);
+        profileBioInput.setSelection(mBio.length());
 
         (getDialog().findViewById(R.id.update_profile_status)).setVisibility(View.INVISIBLE);
 


### PR DESCRIPTION
When editing a bio that already has text, the caret always starts at the beginning of the input.